### PR TITLE
fix: Fix the path error in the release script and change mobile/dist in the pub:theme command to theme-mobile/dist

### DIFF
--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -71,7 +71,6 @@ jobs:
       # 步骤8: 发布组件到NPM
       - name: Publish components
         run: |
-          pnpm --filter @opentiny/vue-mobile publish --tag ${{ inputs.tag }} --access=public --no-git-checks
           pnpm -C packages/theme-mobile/dist publish --tag ${{ inputs.tag }} --access=public --no-git-checks
         env:
           # 使用NPM令牌进行身份验证

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -71,7 +71,8 @@ jobs:
       # 步骤8: 发布组件到NPM
       - name: Publish components
         run: |
-          pnpm -C packages/theme-mobile/dist publish --tag ${{ inputs.tag }} --access=public --no-git-checks
+          pnpm pub --tag ${{ inputs.tag }}
+          pnpm pub:theme --tag ${{ inputs.tag }}
         env:
           # 使用NPM令牌进行身份验证
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish components
         run: |
           pnpm --filter @opentiny/vue-mobile publish --tag ${{ inputs.tag }} --access=public --no-git-checks
-          pnpm -C packages/mobile/dist publish --tag ${{ inputs.tag }} --access=public --no-git-checks
+          pnpm -C packages/theme-mobile/dist publish --tag ${{ inputs.tag }} --access=public --no-git-checks
         env:
           # 使用NPM令牌进行身份验证
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "pnpm -C packages/mobile build",
     "pub": "pnpm -C packages/mobile publish --no-git-checks --access=public",
     "build:theme": "pnpm -C packages/theme-mobile build:fast",
-    "pub:theme": "pnpm -C packages/mobile/dist publish --no-git-checks --access=public"
+    "pub:theme": "pnpm -C packages/theme-mobile/dist publish --no-git-checks --access=public"
   },
   "dependencies": {
     "@vue/composition-api": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "pnpm -C packages/mobile build",
     "pub": "pnpm -C packages/mobile publish --no-git-checks --access=public",
     "build:theme": "pnpm -C packages/theme-mobile build:fast",
-    "pub:theme": "pnpm -C packages/theme-mobile/dist publish --no-git-checks --access=public"
+    "pub:theme": "pnpm --filter=\"./packages/theme-mobile/dist\" publish --access=public --no-git-checks"
   },
   "dependencies": {
     "@vue/composition-api": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev": "pnpm -C sites start:mobile",
     "preSite": "node ./script/preSite.js",
     "build": "pnpm -C packages/mobile build",
-    "pub": "pnpm -C packages/mobile publish --no-git-checks --access=public",
+    "pub": "pnpm --filter=@opentiny/vue-mobile publish --no-git-checks --access=public",
     "build:theme": "pnpm -C packages/theme-mobile build:fast",
     "pub:theme": "pnpm --filter=\"./packages/theme-mobile/dist\" publish --access=public --no-git-checks"
   },

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/vue-mobile",
   "type": "module",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "author": "OpenTiny Team",
   "license": "MIT",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentiny/vue-mobile",
   "type": "module",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "author": "OpenTiny Team",
   "license": "MIT",

--- a/packages/theme-mobile/package.json
+++ b/packages/theme-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-theme-mobile",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "homepage": "https://opentiny.design/tiny-vue",
   "main": "index.css",

--- a/packages/theme-mobile/package.json
+++ b/packages/theme-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-theme-mobile",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "An enterprise-class UI component library, support both Vue.js 2 and Vue.js 3, as well as PC and mobile.",
   "homepage": "https://opentiny.design/tiny-vue",
   "main": "index.css",


### PR DESCRIPTION
fix: 修复发布脚本中的路径错误，将pub:theme命令中的mobile/dist更改为theme-mobile/dist
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/ui-vue/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined publish steps in the release workflow to use simplified commands.
  * Updated project scripts to publish targeted workspace packages for components and theme.
  * Aligned publishing configuration to maintain existing access and integrity settings.
  * Bumped versions for mobile and theme packages to 1.0.0-alpha.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->